### PR TITLE
Allow editing wallet names

### DIFF
--- a/wallet_site/app/wallet_service.py
+++ b/wallet_site/app/wallet_service.py
@@ -226,3 +226,16 @@ def delete_wallets(wallet_ids: List[int], owner: str) -> int:
         
         session.commit()
         return count
+
+def update_wallet_name(wallet_id: int, owner: str, name: str) -> Wallet:
+    """更新钱包名称"""
+    with get_session() as session:
+        wallet = session.get(Wallet, wallet_id)
+        if not wallet or wallet.owner != owner:
+            raise ValueError("wallet not found")
+
+        wallet.name = name
+        session.add(wallet)
+        session.commit()
+        session.refresh(wallet)
+        return wallet

--- a/wallet_site/static/app.js
+++ b/wallet_site/static/app.js
@@ -183,7 +183,7 @@ const loadWallets = async () => {
           <tr>
             <td><input type="checkbox" class="wallet-select" value="${w.id}"></td>
             <td>${w.public_key}</td>
-            <td>${w.name || '-'}</td>
+            <td><span class="wallet-name" data-id="${w.id}">${w.name || '-'}</span></td>
             <td>${w.source}</td>
             <td>${w.balance !== null ? w.balance.toFixed(4) : '-'}</td>
             <td>${new Date(w.created).toLocaleString()}</td>
@@ -202,6 +202,27 @@ const loadWallets = async () => {
   // 单选功能
   $$('.wallet-select').forEach(cb => {
     cb.onchange = updateSelectedWallets;
+  });
+
+  // 编辑名称
+  $$('.wallet-name').forEach(span => {
+    span.onclick = async () => {
+      const id = span.dataset.id;
+      const current = span.textContent === '-' ? '' : span.textContent;
+      const name = prompt('输入新的名称', current);
+      if (name === null) return;
+      try {
+        const r = await authFetch(`/api/wallets/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name })
+        });
+        if (!r.ok) throw new Error('更新失败');
+        span.textContent = name || '-';
+      } catch (e) {
+        alertMsg(e.message);
+      }
+    };
   });
 };
 

--- a/wallet_site/static/styles.css
+++ b/wallet_site/static/styles.css
@@ -178,3 +178,8 @@ input[type="checkbox"] {
   font-weight: 600;
   color: #4caf50;
 }
+
+.wallet-name {
+  cursor: pointer;
+  text-decoration: underline dotted;
+}


### PR DESCRIPTION
## Summary
- allow wallet names to be updated in DB
- expose `/api/wallets/{wallet_id}` endpoint to update names
- allow editing wallet names from UI
- tweak style for editable names

## Testing
- `python -m py_compile $(find wallet_site -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687698ff967c832d80f2ea71e90d247f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to rename wallets directly from the wallet list via inline editing.
* **Bug Fixes**
  * Corrected a missing closing brace in the wallet balance cell styles.
* **Style**
  * Introduced a new visual style for wallet names to indicate they are clickable and editable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->