### PR TITLE
Add modal import wallet UI

### DIFF
--- a/wallet_site/static/index.html
+++ b/wallet_site/static/index.html
@@ -61,7 +61,6 @@
         <button id="exportBtn" class="action-btn" disabled>📤 导出选中</button>
         <button id="balanceBtn" class="action-btn" disabled>💰 查询余额</button>
         <button id="deleteBtn" class="action-btn delete-btn" disabled>🗑️ 删除选中</button>
-        <input type="file" id="importFile" accept=".json" style="display: none;">
       </div>
       
       <!-- 钱包列表 -->
@@ -79,6 +78,18 @@
       <p class="muted">后续将在此处接入 Mint 或二级市场批量购置功能…</p>
     </section>
   </main>
+
+  <!-- 导入钱包弹窗 -->
+  <div id="importModal" class="modal" hidden>
+    <div class="modal-content">
+      <h3>导入私钥（每行一个 JSON，或拖拽文件）</h3>
+      <textarea id="importTextarea" placeholder="粘贴内容或拖入文件"></textarea>
+      <div class="modal-buttons">
+        <button id="importConfirm">导入</button>
+        <button id="importCancel" class="delete-btn">取消</button>
+      </div>
+    </div>
+  </div>
 
   <!-- 业务脚本 -->
   <script type="module" src="/static/app.js"></script>

--- a/wallet_site/static/styles.css
+++ b/wallet_site/static/styles.css
@@ -196,3 +196,39 @@ input[type="checkbox"] {
   cursor: pointer;
   text-decoration: underline dotted;
 }
+
+/* 导入弹窗样式 */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 500px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+#importTextarea {
+  width: 100%;
+  height: 180px;
+  margin-top: 10px;
+  padding: 8px;
+  font-family: monospace;
+  border: 1px dashed #aaa;
+}
+
+.modal-buttons {
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}


### PR DESCRIPTION
## Summary
- add import modal markup and remove old file input
- add styles for import modal
- implement modal logic in frontend JS

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876ae54a918832db4aa909bc4cbbe36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a modal dialog for wallet import, allowing users to paste or drag-and-drop JSON-formatted private keys.
  * Added a textarea within the modal for easier input and file handling.

* **Style**
  * Updated styles to support the new modal dialog, including overlay, modal content, and improved textarea appearance.

* **Refactor**
  * Replaced the previous hidden file input method with the new modal-based import workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->